### PR TITLE
Update README.md to document isHttpOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ server.pack.allow({ ext: true }).require('yar', options, function (err) { });
     - `password` - (Required) used to encrypt and sign the cookie data.
     - `path` - determines the cookie path. Defaults to _'/'_.
     - `isSecure` - determines whether or not to transfer using TLS/SSL. Defaults to _true_.
+    - `isHttpOnly` - determines whether or not to set HttpOnly option in cookie. Defaults to _false_.
 
 
 #### Methods


### PR DESCRIPTION
Option found from here.
https://github.com/spumko/hapi/blob/master/docs/Reference.md#serverstatename-options

I confirmed with OWASP ZAP that this properly sets HttpOnly.
https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project

You might want to consider setting isHttpOnly to _true_ by default.
