### PR TITLE
Add note in README about using inSecure: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ The plugin requires a password for encryption, and the `ext` permission:
 ```javascript
 var options = {
     cookieOptions: {
-        password: 'password', // Required
-        isSecure: false // Required if using http
+        password: 'password'
     }
 };
 
@@ -44,6 +43,8 @@ var server = new Hapi.Server();
 
 server.pack.allow({ ext: true }).require('yar', options, function (err) { });
 ```
+
+Note: Add `isSecure: false` to the `cookieOptions` if using standard http. Take care to do this in development mode only though. You don't want to use cookies sent over insecure channels for session management. 
 
 
 ## API Reference


### PR DESCRIPTION
I spent 30 minutes wondering what I was doing wrong with yar during development. Turned out I needed to set inSecure to false. This was not immediately visible to me - till I dug into the code. 

This README update should save others the same pain.
