### PR TITLE
session is stored before sending response!

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -175,7 +175,7 @@ exports.register = function (plugin, options, next) {
     
     // Post handler
     
-    plugin.ext('onPostHandler', function (request, callback) {
+    plugin.ext('onPreResponse', function (request, callback) {
 
         if (!request.session._isModified &&
             !request.session._isLazy) {


### PR DESCRIPTION
This allow to save session even if a plugin or an auth system has to redirect before handlers could execute!
