### PR TITLE
Update to hapi 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "node-uuid": "1.4.x"
   },
   "peerDependencies": {
-    "hapi": "2.x.x"
+    "hapi": ">=2 <4"
   },
   "devDependencies": {
-    "hapi": "2.x.x",
+    "hapi": "3.x",
     "lab": "1.x.x"
   },
   "scripts": {


### PR DESCRIPTION
This is really a "pull request as question."

I'm interested in using the hapi 3.0.0 release, but can't find information on what else does/doesn't work with it in the Spumko ecosystem.  For yar, the tests pass with `hapi@3.0.0`.  Does this mean the two can be used together?

I've got the same question about travelogue (where tests also pass with `hapi@3.0.0`).  Thanks for any tips.  Ok by me if this gets closed and the answer is "don't use hapi 3 yet."
