### PR TITLE
Fix #34: check for state error onPreResponse.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -178,6 +178,13 @@ exports.register = function (plugin, options, next) {
 
     plugin.ext('onPreResponse', function (request, reply) {
 
+        if (!request.session) {
+
+            // onPreAuth was skipped because of a state error
+
+            return reply();
+        }
+
         if (!request.session._isModified &&
             !request.session._isLazy) {
 

--- a/test/index.js
+++ b/test/index.js
@@ -544,6 +544,36 @@ describe('Yar', function () {
         });
     });
 
+    it('fails to store session because of state error', function (done) {
+
+        var options = {
+            maxCookieSize: 0,
+            cookieOptions: {
+                password: 'password',
+                isSecure: false
+            }
+        };
+
+        var headers = {
+            Cookie: 'session=Fe26.2**deadcafe' // bad session value
+        };
+
+        var server = new Hapi.Server(0, { debug: false });
+
+        server.pack.require('../', options, function (err) {
+
+            expect(err).to.not.exist;
+            server.start(function () {
+
+                server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
+
+                    expect(res.statusCode).to.equal(400);
+                    done();
+                });
+            });
+        });
+    });
+
     describe("#flash", function () {
 
         it('should get all flash messages when given no arguments', function (done) {


### PR DESCRIPTION
If hapi detects a problem with state, e.g. if cookie decryption fails,
the onPreAuth handler will be skipped and request.session will remain
unset. Check if the session exists before handling it.
