### PR TITLE
added skip setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Note: Add `isSecure: false` to the `cookieOptions` if using standard http. Take 
     - `path` - determines the cookie path. Defaults to _'/'_.
     - `isSecure` - determines whether or not to transfer using TLS/SSL. Defaults to _true_.
     - `isHttpOnly` - determines whether or not to set HttpOnly option in cookie. Defaults to _false_.
+- 'skip' - a function with the signature of `function (request reply) {}`, which when provided, is called for every request. If the provided function returns true no session with be attached to the request (defaults to false).
 
 
 #### Methods

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ internals.defaults = {
     cookieOptions: {                            // hapi server.state() options, except 'encoding' which is always 'iron'. 'password' required.
         path: '/',
         isSecure: true
-    }
+    },
+    skip: false
 };
 
 
@@ -47,6 +48,12 @@ exports.register = function (server, options, next) {
     // Pre auth
 
     server.ext('onPreAuth', function (request, reply) {
+
+        // If skip function enabled. Call it and if returns true, do not attempt to do anything with yar.
+
+        if (settings.skip && typeof settings.skip === 'function' && settings.skip(request, reply)) {
+            return reply.continue();
+        }
 
         // Load session data from cookie
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ exports.register = function (server, options, next) {
 
         // If skip function enabled. Call it and if returns true, do not attempt to do anything with yar.
 
-        if (settings.skip && typeof settings.skip === 'function' && settings.skip(request, reply)) {
+        if (typeof settings.skip === 'function' && settings.skip(request, reply)) {
             return reply.continue();
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -657,6 +657,40 @@ it('ignores requests when session is not set (error)', function (done) {
     });
 });
 
+it('ignores requests when the skip function returns true', function (done) {
+
+    var options = {
+        skip: function(request, reply) {
+            return true;
+        }
+    };
+
+    var server = new Hapi.Server();
+    server.connection();
+
+    server.route([
+        {
+            method: 'GET', path: '/', handler: function (request, reply) {
+                return reply('1');
+            }
+        }
+    ]);
+
+    server.register({ register: require('../'), options: options }, function (err) {
+
+        expect(err).to.not.exist();
+        server.start(function () {
+
+            server.inject({ method: 'GET', url: '/' }, function (res) {
+
+                var header = res.headers['set-cookie'];
+                expect(header).to.be.undefined();
+                done();
+            });
+        });
+    });
+});
+
 describe('flash()', function () {
 
     it('should get all flash messages when given no arguments', function (done) {


### PR DESCRIPTION
Adds a setting so that cookies will not be set on specific routes. This is particularly useful for serving static assets.


```
  // Assets
  {
    method: "GET",
    path: "/assets/{path*}",
    config: {
      plugins: {
        yar: {
          skip: true
        },
      }
    },
    handler: {
      directory: { path: './public/assets'}
    }
  }
```

This solved issue #68 for me.