### PR TITLE
Fix plugin registration example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var options = {
 var server = new Hapi.Server();
 
 server.register({
-    plugin: require('yar'),
+    register: require('yar'),
     options: options
 }, function (err) { });
 ```


### PR DESCRIPTION
hapi 8.1.0's plugin logic was throwing an error when trying to register `yar` using the README code snippet.