### PR TITLE
Allow specification of whether to store blank sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Hapi 7.x or below: You must use `server.pack.register`
 
 - `name` - determines the name of the cookie used to store session information. Defaults to _session_.
 - `maxCookieSize` - maximum cookie size before using server-side storage. Defaults to 1K. Set to zero to always use server-side storage.
+- `storeBlank` - determines whether to store empty session before they've been modified. Defaults to _true_.
 - `cache` - **hapi** [cache options](https://github.com/hapijs/hapi/blob/master/API.md#servercacheoptions) which includes
   (among other options):
     - `expiresIn` - server-side storage expiration (defaults to 1 day).

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ var internals = {};
 internals.defaults = {
     name: 'session',                            // Cookie name
     maxCookieSize: 1024,                        // Maximum size allowed in a cookie
+    storeBlank: true,                           // Initially _isModified
     cache: {
         expiresIn: 24 * 60 * 60 * 1000          // One day session
     },
@@ -79,7 +80,7 @@ exports.register = function (server, options, next) {
             request.session = {
                 id: Uuid.v4(),
                 _store: {},
-                _isModified: true
+                _isModified: settings.storeBlank
             };
 
             decorate();


### PR DESCRIPTION
We've been using Yar for sessions, and storing sessions in Redis. Over time, a very large number of entirely empty sessions have accumulated; these are created on requests with authentication is optional, which in our case is the majority of routes.

This PRs adds an option, `storeBlank` which simply sets the initial `_isModified` property, which causes new sessions that are not changed to not be persisted or sent down in the set-cookie. It defaults to `true` - which is the current behaviour of the library - so no breaking change is introduced.