### PR TITLE
add a route level config option to skip yar processing

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,6 +18,10 @@
     - `isHttpOnly` - determines whether or not to set HttpOnly option in cookie. Defaults to _false_.
     - `ttl` - sets the time for the cookie to live in the browser, in milliseconds.  Defaults to null (session time-life - cookies are deleted when the browser is closed).
 
+#### Route Options
+You can also add these options on a route per route basis at `config.plugins.yar`:
+    - `skip` - a boolean value which, if true, means no session with be attached to the request (defaults to false).
+
 
 #### Methods
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,11 @@ exports.register = (server, options, next) => {
 
     server.ext('onPreAuth', (request, reply) => {
 
+        // If this route configuration indicates to skip, do nothing.
+        if (request.route.settings.plugins.yar && request.route.settings.plugins.yar.skip === true) {
+            return reply.continue();
+        }
+
         // Load session data from cookie
 
         const load = () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ internals.defaults = {
     cache: {
         expiresIn: 24 * 60 * 60 * 1000          // One day session
     },
-    cookieOptions: {                            // hapi server.state() options, except 'encoding' which is always 'iron'. 'password' required.
+    cookieOptions: {                            // hapi server.state() options, except 'encoding' which is always 'iron'. 'password' is required.
         path: '/',
         isSecure: true,
         ignoreErrors: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ exports.register = (server, options, next) => {
     server.ext('onPreAuth', (request, reply) => {
 
         // If this route configuration indicates to skip, do nothing.
-        if (request.route.settings.plugins.yar && request.route.settings.plugins.yar.skip === true) {
+        if (Hoek.reach(request, 'route.settings.plugins.yar.skip')) {
             return reply.continue();
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1075,6 +1075,48 @@ it('ignores requests when session is not set (error)', (done) => {
     });
 });
 
+it('ignores requests when the skip route config value is true', (done) => {
+
+    const options = {
+        cookieOptions: {
+            password: 'password'
+        }
+    };
+    const server = new Hapi.Server();
+    server.connection();
+
+    server.route([
+        {
+            method: 'GET', path: '/',
+            handler: (request, reply) => {
+
+                return reply('1');
+            },
+            config: {
+                plugins: {
+                    yar: {
+                        skip: true
+                    }
+                }
+            }
+        }
+    ]);
+
+    server.register({ register: require('../'), options }, (err) => {
+
+        expect(err).to.not.exist();
+        server.start(() => {
+
+            server.inject({ method: 'GET', url: '/' }, (res) => {
+
+                const header = res.headers['set-cookie'];
+                expect(header).to.be.undefined();
+                done();
+            });
+        });
+    });
+});
+
 describe('flash()', () => {
 
     it('should get all flash messages when given no arguments', (done) => {


### PR DESCRIPTION
There was a PR #69 that was abandoned along the way, but I believe it provides a useful addition.  I've recreated the functionality.  This PR allows you to add a route level skip option to prevent yar from processing requests to particular endpoints.  This skips the overhead of session cookie creation and tracking for those requests where it would be meaningless.  To skip any yar processing of a route add:

```
config: {
  plugins: {
    yar: {
      skip: true
    }
  }
}
```