### PR TITLE
Fix `main` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Cookie jar plugin for Hapi",
   "version": "8.1.1",
   "repository": "git://github.com/hapijs/yar",
-  "main": "lib/index",
+  "main": "lib/index.js",
   "keywords": [
     "hapi",
     "plugin",


### PR DESCRIPTION
Some tools don't work if the `main` entry does not have a file extension, for example TypeScript:

```js
error TS2307: Cannot find module 'yar'.
```