### PR TITLE
Do not cast all falsy values to null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,7 +152,7 @@ const registerPlugin = (server, options) => {
                             request.yar.clear(key);
                         }
 
-                        return value || null;
+                        return value === undefined ? null : value;
                     };
 
                     request.yar.set = (key, value) => {


### PR DESCRIPTION
Fix #121.

I kept `undefined` casted to `null` to keep this change non-breaking. It seems to be common to `return request.yar.get('stored')`, and hapi will complain if controller returns `undefined`.