### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "jar",
     "session"
   ],
-  "engines": {
-    "node": ">=8.0.0"
-  },
+  "files": [
+    "lib"
+  ],
   "dependencies": {
-    "hoek": "5.x.x",
+    "hoek": "6.x.x",
     "statehood": "6.x.x",
     "uuid": "3.x.x"
   },
@@ -23,13 +23,11 @@
     "boom": "7.x.x",
     "code": "5.x.x",
     "hapi": "17.x.x",
-    "lab": "16.x.x",
-    "npmignore": "0.2.x"
+    "lab": "17.x.x"
   },
   "scripts": {
     "test": "lab -a code -t 100 -L",
-    "test-cov-html": "lab -a code -r html -o coverage.html",
-    "update-npmignore": "npmignore"
+    "test-cov-html": "lab -a code -r html -o coverage.html"
   },
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Updates hoek to avoid duplicate dependencies in use with latest hapi.

Not sure why this package ever used an .npmignore generator when you can just cherry pick files, remove that.