### PR TITLE
Fix link to cookie options in API reference

### DIFF
--- a/API.md
+++ b/API.md
@@ -66,7 +66,7 @@ Keep in mind some things in regard to your password:
 
 ## Cookie Options
 
-You can read about more cookie options in the [Api](API.md).
+You can read about more cookie options in the [cookie options](#options) section.
 
 ### isSecure
 


### PR DESCRIPTION
The existing link doesn't work when used at the [hapi.dev](https://hapi.dev/family/yar/api/?v=10.0.0#cookie-options) site. Using an anchor to reference the same file seems to be working in both github and hapi.dev.