### PR TITLE
Use crypto.randomUUID as default session id

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        node: ['*', '14', '12']
+        node: ['*', '16', '14']
         hapi: ['20', '19']
 
     runs-on: ${{ matrix.os }}-latest

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const Crypto = require('crypto');
 const Hoek = require('@hapi/hoek');
 const Statehood = require('@hapi/statehood');
-const Uuid = require('uuid');
 
 
 const internals = {
@@ -28,6 +28,7 @@ const internals = {
 exports.plugin = {
     pkg: require('../package.json'),
     requirements: {
+        node: '>=14.17.0',
         hapi: '>=19.0.0'
     },
 
@@ -157,7 +158,7 @@ internals.Yar = class {
 
     _generateSessionID() {
 
-        const id = this._settings.customSessionIDGenerator ? this._settings.customSessionIDGenerator(this._request) : Uuid.v4();
+        const id = this._settings.customSessionIDGenerator ? this._settings.customSessionIDGenerator(this._request) : Crypto.randomUUID();
         Hoek.assert(typeof id === 'string', 'Session ID should be a string');
         return id;
     }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "dependencies": {
     "@hapi/hoek": "9.x.x",
-    "@hapi/statehood": "7.x.x",
-    "uuid": "^8.3.0"
+    "@hapi/statehood": "7.x.x"
   },
   "devDependencies": {
     "@hapi/boom": "9.x.x",


### PR DESCRIPTION
Uses `crypto.randomUUID()` instead of `uuid.v4()` to generate the default session id.

Solves #156 