### PR TITLE
Support hapi v21, drop hapi v19, test ESM support

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -13,3 +13,4 @@ jobs:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
     with:
       min-node-version: 14
+      min-hapi-version: 20

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,9 +29,8 @@ exports.plugin = {
     pkg: require('../package.json'),
     requirements: {
         node: '>=14.17.0',  // Support of Crypto.randomUUID()
-        hapi: '>=19.0.0'
+        hapi: '>=20.0.0'
     },
-
     register: function (server, options) {
 
         // Validate options and apply defaults

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hapi/yar",
-  "description": "Cookie jar plugin for Hapi",
+  "description": "Cookie jar plugin for hapi",
   "version": "10.1.1",
   "repository": "git://github.com/hapijs/yar",
   "main": "lib/index.js",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@hapi/boom": "^10.0.0",
     "@hapi/code": "^9.0.0",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "^20.2.2",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
     "@hapi/lab": "^25.0.1"
   },
   "scripts": {

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Yar;
+
+    before(async () => {
+
+        Yar = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Yar)).to.equal([
+            'default',
+            'plugin'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Support and test on hapi v21, drop support for hapi v19.
 - Test ESM support.

If this looks good, this will be the final addition to yar v11.