### PR TITLE
FEATURE: Add pop(key) method

### DIFF
--- a/API.md
+++ b/API.md
@@ -127,6 +127,7 @@ You can also add these options on a route per route basis at `config.plugins.yar
 - `set(key, value)` - assigns a value (string, object, etc) to a given key which will persist across requests.  Returns the value.
 - `set(keysObject)` - assigns values to multiple keys using each 'keysObject' top-level property. Returns the keysObject.
 - `get(key, clear)` - retrieve value using a key. If 'clear' is 'true', key is cleared on return.
+- `pop(key)` - retrieve value using a key and removes it on return.
 - `clear(key)` - clears key.
 - `touch()` - Manually notify the session of changes (when using `get()` and changing the content of the returned reference directly without calling `set()`).
 - `flash(type, message, isOverride)` - stores volatile data - data that should be deleted once read. When given no arguments, it will return all of the flash messages and delete the originals. When given only a type, it will return all of the flash messages of that type and delete the originals. When given a type and a message, it will set or append that message to the given type. 'isOverride' used to indicate that the message provided should replace any existing value instead of being appended to it (defaults to false).

--- a/lib/index.js
+++ b/lib/index.js
@@ -182,6 +182,19 @@ internals.Yar = class {
         return value === undefined ? null : value;
     }
 
+    pop(key) {
+
+        const value = this._store[key];
+
+        if (!value) {
+            return null;
+        }
+
+        this.clear(key);
+
+        return value;
+    }
+
     set(key, value) {
 
         Hoek.assert(key, 'Missing key');


### PR DESCRIPTION
## :unicorn: Context

When we first used this plugin, we wondered if there was a way to retrieve and delete a value. We found in the documentation that the `get` method accepts an additional parameter, which is the delete option after retrieval.

For new developers on the project or people who will be reviewing the code, a recurring question we've noticed is what the second parameter of the `get` method does?

It could be great to have a method with more clarity like [Array.prototype.pop()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop) to retrieve and delete a value.

## :robot: Proposal

Add a new method with the name `pop` which retrieves and removes the value associated with the specified key from the request yar store.

## :rainbow: Notes

N/A

## :100: Tests

1. Run the commands `npm test` and/or `npm run test-cov-html`
2. Check tests are all ✅ 